### PR TITLE
Fix .NET build

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -2,6 +2,9 @@ name: .NET Core
 
 on: [push]
 
+env:
+  DOTNET_VERSION: '3.1.301'
+
 jobs:
   build:
 
@@ -9,15 +12,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Setup .NET Core
+
+    - name: Setup DotNet ${{ env.DOTNET_VERSION }} Environment
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.101
-    - name: Setup Nuget.exe
-      uses: warrenbuckley/Setup-Nuget@v1
-    - name: Restore NuGet packages
-      run: nuget restore ./Surfrider.PlasticOrigins.Backend.Mobile.sln
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+
+    - name: Setup NuGet & Restore
+      uses: nuget/setup-nuget@v1
+      run: nuget restore Surfrider.PlasticOrigins.Backend.Mobile.sln
+
     - name: Build with dotnet
       run: dotnet build --configuration Release
+
     - name: Test with dotnet
       run: dotnet test ./Surfrider.PlasticOrigins.Backend.Mobile.sln --configuration Release

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -18,8 +18,10 @@ jobs:
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
-    - name: Setup NuGet & Restore
+    - name: Setup NuGet
       uses: nuget/setup-nuget@v1
+
+    - name: Restore NuGet packages
       run: nuget restore Surfrider.PlasticOrigins.Backend.Mobile.sln
 
     - name: Build with dotnet


### PR DESCRIPTION
Old Nuget action was using a deprecated add-path command. See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/